### PR TITLE
.dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.env
+*.env
+*.log
+.vscode/
+.git/


### PR DESCRIPTION
pour ne pas copier les fichiers inutiles dans l’image